### PR TITLE
Reading altitude with epygram and lookup table columns with LIMA

### DIFF
--- a/operadar/read/arome.py
+++ b/operadar/read/arome.py
@@ -101,7 +101,6 @@ def read_arome(filePath:Path,
                             )
     if verbose : print('\t\tGot 3D concentrations in',round(tm.time()-deb,3),'seconds'); deb=tm.time()
     
-    T=T-273.15
     X = X_res*np.arange(T.shape[2]).astype('i4')
     Y = Y_res*np.arange(T.shape[1]).astype('i4')
     Alt = get_altitude(hybrid_pressure_coefA=A,
@@ -112,6 +111,7 @@ def read_arome(filePath:Path,
                        surface_geopotential=geosurf,
                        specific_gas_constant=R,
                        )
+    T=T-273.15
     if verbose : print('\t\tComputed altitude 3D field in',round(tm.time()-deb,3),'seconds'); deb=tm.time()
     
     loaded_epygram_file.close()

--- a/operadar/read/lookup_tables.py
+++ b/operadar/read/lookup_tables.py
@@ -41,9 +41,7 @@ def retrieve_needed_columns(dpol2add:list,scattering_method:str='Tmatrix')->list
     """Depending on the variables the user wants to compute and the chosen scattering method,
     creating a list of the table's column names to extract."""
     
-    table_columnNames = ['Tc', 'ELEV', 'M']
-    if micro_scheme[0:3]=='ICE' : table_columnNames +=['Fw'] # to remove later ?
-    elif micro_scheme[0:3]=='LIM' : table_columnNames +=['N'] # to remove later ?
+    table_columnNames = ['Tc', 'ELEV', 'M', 'Fw', 'N']
     
     if scattering_method == 'Tmatrix' or scattering_method == 'both' :
         if 'Zh' in dpol2add :
@@ -127,12 +125,11 @@ def read_and_extract_tables_content(band:str,
         if verbose : print("\tRetrieving necessary columns in the table for",h)
         df_columns = pd.read_csv(nomfileCoefInt, sep=";",skiprows = [0, 1])
         for columnName in columns_to_retrieve :
-            if columnName == 'Fw' and hydrometeors_moments[h]==1 :
-                table_dict[columnName][h] = df_columns['P3'].to_numpy()
-                #table_dict['N'][h] = df_columns['P3'].to_numpy()*0
-            elif columnName == 'N' and hydrometeors_moments[h]==2 :
-                table_dict[columnName][h] = df_columns['P3'].to_numpy()
-                #table_dict['Fw'][h] = df_columns['P3'].to_numpy()*0
+            if columnName == 'Fw' or columnName == 'N' :
+                if hydrometeors_moments[h]==1 :
+                    table_dict['Fw'][h] = df_columns['P3'].to_numpy()
+                elif hydrometeors_moments[h]==2 :
+                    table_dict['N'][h] = df_columns['P3'].to_numpy()
             else :
                 table_dict[columnName][h] = df_columns[columnName].to_numpy()
         del df_columns


### PR DESCRIPTION
Two updates : 
1. The conversion of AROME temperatures from Kelvin to Celsius is now performed AFTER the reading of the altitude field with epygram (before : was creating incorrect fields of altitude)
2. The reading of the lookup tables' columns have been adapted depending on the microphysics scheme name AND the number of moment provided in the template file (before : only the scheme name was used to determine what column to read, which was done wrong for mixed moments configurations)